### PR TITLE
improved sql query for mql tracking

### DIFF
--- a/models/salesforce/salesforce_marts/fct_mqls.sql
+++ b/models/salesforce/salesforce_marts/fct_mqls.sql
@@ -1,4 +1,9 @@
 
+with 
+
+-- all leads with a lifecycle status change to MQL
+mqls as (
+
 select 
 
 id,
@@ -7,3 +12,40 @@ created_date
 
 from {{ ref('stg_lead_history') }}
 where new_value = 'MQL' and field = 'Lifecycle_Status__c' and is_deleted = false
+
+),
+
+--leads that came into salesforce as MQLs and therefore do not have lifecycle status change tracked
+leads as (
+
+select 
+
+lead_id,
+created_date
+
+from {{ ref('dim_leads_with_owner') }}
+where mql_date is not null
+and lead_id not in (select lead_id from mqls)
+and mql_date >= '2022-03-24' --history field tracking activated for lifecycle status on this date
+
+)
+
+select 
+
+id,
+lead_id,
+created_date
+
+from mqls
+union all
+select
+
+null as id,
+lead_id,
+created_date
+
+from leads
+order by created_date desc
+
+
+

--- a/models/salesforce/salesforce_staging/stg_leads.sql
+++ b/models/salesforce/salesforce_staging/stg_leads.sql
@@ -61,7 +61,7 @@ is_deleted,
  
 -- date fields
     
-date(created_date) as created_date,
+to_timestamp(created_date) as created_date,
 date(date_stage_mal_c) as mal_date,
 date(date_stage_mel_c) as mel_date,
     


### PR DESCRIPTION
history tracking for mql field only works if the lead comes into the system as a lead and not as mql. Added query to get this data and combine it with mql tracking.