### PR TITLE
Lead Funnel Stage Data + Campaign Activity Data

### DIFF
--- a/models/marketing/activation_marketing/lead_funnel_stage_data.sql
+++ b/models/marketing/activation_marketing/lead_funnel_stage_data.sql
@@ -1,0 +1,53 @@
+with
+    first_attributed_opportunities as (
+        select
+            *
+        from {{ ref('int_sf_opportunity')}}
+        where
+            attribution_contact_opp_number = 1
+    )
+    ,sales_activity_stage_data as (
+        select
+            email
+            ,hubspot_contact_id
+            ,min(activity_date) as initial_reach_out_date
+            ,min(case when activity_direction = 'Response' then activity_date else null end) as initial_response_date
+        from {{ ref('int_sf_sales_activities')}}
+        group by email, hubspot_contact_id
+    )
+
+
+select
+    hc.email
+    ,hc.id as hubspot_contact_id
+    ,hc.sfdc_lead_id as salesforce_lead_id
+    ,hc.sfdc_contact_id as salesforce_contact_id
+ --   ,created_date
+    ,fo.id as converted_opportunity_id
+    ,fo.net_new_arr_forecast_c as pipeline
+    ,fo.stage_1_date_c
+    ,fo.stage_2_date_c
+    ,fo.stage_3_date_c
+    ,fo.stage_4_date_c
+    ,fo.stage_5_date_c
+    ,case when fo.is_won = true and fo.is_closed = true then fo.close_date else null end as closed_won_date
+    ,case when fo.stage_1_date_c is not null then 1 else 0 end as stage_1_opp
+    ,case when fo.stage_2_date_c is not null then 1 else 0 end as stage_2_opp
+    ,case when fo.stage_3_date_c is not null then 1 else 0 end as stage_3_opp
+    ,case when fo.stage_4_date_c is not null then 1 else 0 end as stage_4_opp
+    ,case when fo.stage_5_date_c is not null then 1 else 0 end as stage_5_opp
+    ,case when fo.is_won = true and fo.is_closed = true then 1 else 0 end as closed_won_opp
+    ,case when fo.is_won = true and fo.is_closed = true then fo.net_new_arr_forecast_c else 0 end closed_won_amount
+    ,coalesce(sa.initial_reach_out_date, sa.initial_response_date, fo.created_date) as reaching_out_date
+    ,coalesce(sa.initial_response_date, fo.created_date) as engaged_date
+    ,fo.created_date as opp_conversion_date
+    ,case when sa.initial_reach_out_date is not null then 1 
+            when fo.id is not null then 1 else 0 end as is_reaching_out_lead
+    ,case when sa.initial_response_date is not null then 1 
+            when fo.id is not null then 1 else 0 end as is_engaged_lead
+    ,case when fo.id is not null then 1 else 0 end as converted_to_opp_lead
+from {{ ref('int_hubspot_contacts')}} hc
+left join first_attributed_opportunities fo
+    on hc.sfdc_contact_id = fo.attribution_contact_id
+left join sales_activity_stage_data sa
+    on hc.id = sa.hubspot_contact_id

--- a/models/marketing/int_marketing/int_sf_opportunity.sql
+++ b/models/marketing/int_marketing/int_sf_opportunity.sql
@@ -20,6 +20,16 @@ with
 select
     oa.*
     ,c.email as attribution_contact_email
+    ,row_number() over (partition by oa.attribution_contact_id order by oa.created_date) as attribution_contact_opp_number
+    ,hc.acquisition_channel_type
+    ,hc.acquisition_channel
+    ,hc.acquisition_channel_detail
+    ,hc.acquisition_channel_campaign
+    ,hc.lead_creation_source_type
+    ,hc.lead_create_source as lead_creation_source
+    ,hc.lead_create_source_detail as lead_creation_source_detail
 from opps_with_attribution_contact_id oa
 left join {{ ref('int_sf_contact')}} c
     on oa.attribution_contact_id = c.id
+left join {{ ref('int_hubspot_contacts')}} hc
+    on c.email = hc.email

--- a/models/marketing/int_marketing/int_sf_sales_activities.sql
+++ b/models/marketing/int_marketing/int_sf_sales_activities.sql
@@ -16,6 +16,11 @@ with
                 else 'Other' end as type
             ,t.subject
             ,t.description
+            ,case when subject like 'Email:%>>%' then 'Reach Out'
+                    when subject like 'LinkedIn Connect: >>%' then 'Reach Out'
+                  when subject like 'Email:%<<%' then 'Response' 
+                    when lower(subject) like '%inmail%response%' then 'Response'
+                  else 'Unknown' end as activity_direction
         from {{ ref('stg_sf_task')}} t
         left join {{ ref('int_sf_lead')}} l
             on t.who_id = l.id
@@ -39,6 +44,7 @@ with
                 ,'Meeting' as type
                 ,e.subject
                 ,e.description
+                ,'Response' as activity_direction
             from {{ ref('stg_sf_event')}} e
             left join {{ ref('int_sf_lead')}} l
                 on e.who_id = l.id
@@ -68,6 +74,7 @@ select
     ,a.type
     ,a.subject
     ,a.description
+    ,a.activity_direction
 from sales_activities a
 left join {{ ref('int_hubspot_contacts')}} hc
     on a.email = hc.email

--- a/models/marketing/marketing_models.yml
+++ b/models/marketing/marketing_models.yml
@@ -8,6 +8,12 @@ models:
         tests:
           - not_null
           - unique
+  - name: lead_funnel_stage_data
+    columns:
+      - name: hubspot_contact_id
+        tests:
+          - not_null
+          - unique
 
 
 


### PR DESCRIPTION
Lead funnel stage data has been hard coded into a Hightouch model. Moving this to dbt with a couple of key changes:

- Fixed logic around contacts that were associated with multiple opportunities, which was leading to failures in the hightouch sync and inaccurate funnel data (duplicate counting of these contacts)
- Refined the sales activity data with an improved dbt model

Also included in this PR is a new campaign activity data model that will push data to Salesforce campaign members.