### PR TITLE
Adding Opportunity Attribution Data Activation Data Model

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -46,10 +46,6 @@ models:
       salesforce_marts:
         +materialized: table
 
-    marketing:
-      +database: "{{ target.database }}"
-      +schema: "{{ target.schema }}"
-
       marketing_staging:
         +materialized: view
 

--- a/models/marketing/activation_marketing/opportunity_attribution_data.sql
+++ b/models/marketing/activation_marketing/opportunity_attribution_data.sql
@@ -1,0 +1,14 @@
+select
+    id
+    ,attribution_contact_email
+    ,attribution_contact_id
+    ,attribution_hubspot_contact_id
+    ,acquisition_channel
+    ,acquisition_channel_detail
+    ,acquisition_channel_campaign
+    ,acquisition_channel_keyword
+    ,lead_creation_source
+    ,lead_creation_source_detail
+from {{ ref('int_sf_opportunity')}}
+where
+    attribution_contact_id is not null

--- a/models/marketing/int_marketing/int_sf_opportunity.sql
+++ b/models/marketing/int_marketing/int_sf_opportunity.sql
@@ -20,11 +20,13 @@ with
 select
     oa.*
     ,c.email as attribution_contact_email
+    ,hc.id as attribution_hubspot_contact_id
     ,row_number() over (partition by oa.attribution_contact_id order by oa.created_date) as attribution_contact_opp_number
     ,hc.acquisition_channel_type
     ,hc.acquisition_channel
     ,hc.acquisition_channel_detail
     ,hc.acquisition_channel_campaign
+    ,hc.acquisition_channel_keyword
     ,hc.lead_creation_source_type
     ,hc.lead_create_source as lead_creation_source
     ,hc.lead_create_source_detail as lead_creation_source_detail


### PR DESCRIPTION
Addition of data model that will push attribution data to Salesforce Opps / HubSpot Deals.

Also, making a configuration change to fix marketing production runs.